### PR TITLE
Preserve fields order in JSON schemes

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaEntity.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaEntity.java
@@ -2,7 +2,7 @@ package com.stanfy.helium.handler.codegen.json.schema;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +36,7 @@ class JsonSchemaEntity {
 
   public void addProperty(final String propertyName, final JsonSchemaEntity property) {
     if (properties == null) {
-      this.properties = new HashMap<String, JsonSchemaEntity>();
+      this.properties = new LinkedHashMap<String, JsonSchemaEntity>();
     }
 
     properties.put(propertyName, property);

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaGeneratorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/json/schema/JsonSchemaGeneratorSpec.groovy
@@ -67,12 +67,12 @@ class JsonSchemaGeneratorSpec extends Specification {
   "type": "object",
   "description": "Test description",
   "properties": {
-    "field2": {
-      "type": "number"
-    },
     "field1": {
       "type": "string",
       "description": "Field1 description"
+    },
+    "field2": {
+      "type": "number"
     }
   },
   "required": [
@@ -107,6 +107,13 @@ class JsonSchemaGeneratorSpec extends Specification {
   "type": "object",
   "description": "Test description",
   "properties": {
+    "field1": {
+      "type": "string",
+      "description": "Field1 description"
+    },
+    "field2": {
+      "type": "number"
+    },
     "field3": {
       "type": "object",
       "description": "Field3 description",
@@ -119,13 +126,6 @@ class JsonSchemaGeneratorSpec extends Specification {
       "required": [
         "nestedField"
       ]
-    },
-    "field2": {
-      "type": "number"
-    },
-    "field1": {
-      "type": "string",
-      "description": "Field1 description"
     }
   },
   "required": [
@@ -165,6 +165,13 @@ class JsonSchemaGeneratorSpec extends Specification {
   "type": "object",
   "description": "Test description",
   "properties": {
+    "field1": {
+      "type": "string",
+      "description": "Field1 description"
+    },
+    "field2": {
+      "type": "number"
+    },
     "field3": {
       "type": "array",
       "description": "Field3 description",
@@ -181,13 +188,6 @@ class JsonSchemaGeneratorSpec extends Specification {
           "nestedField"
         ]
       }
-    },
-    "field2": {
-      "type": "number"
-    },
-    "field1": {
-      "type": "string",
-      "description": "Field1 description"
     }
   },
   "required": [


### PR DESCRIPTION
Also fixes this build failure (order on Java 7 and Java 8 was
different): https://travis-ci.org/stanfy/helium/jobs/36163930

/cc @lampapos 
