### PR TITLE
Create aggregation source gen tasks

### DIFF
--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/SourceGenDslDelegate.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/SourceGenDslDelegate.groovy
@@ -4,6 +4,7 @@ import com.stanfy.helium.gradle.internal.SourceCodeGenerators
 import com.stanfy.helium.gradle.tasks.BaseHeliumTask
 import com.stanfy.helium.utils.DslUtils
 import groovy.transform.PackageScope
+import org.gradle.api.Task
 
 import static com.stanfy.helium.gradle.UserConfig.specName
 
@@ -56,9 +57,14 @@ class SourceGenDslDelegate {
     delegatesMap[name] = generator
   }
 
+  /**
+   * Create source generation tasks for the defined specification.
+   * @return a map {@code }
+   */
   @PackageScope
-  void createTasks(final UserConfig userConfig, final File specification, final URL[] classpath,
-                   final String basePath, final HeliumExtension config) {
+  Map<String, Task> createTasks(final UserConfig userConfig, final File specification, final URL[] classpath,
+                                            final String basePath, final HeliumExtension config) {
+    def tasksMap = [:]
     delegatesMap.each { String name, GeneratorDslDelegate delegate ->
       if (!delegate) {
         return
@@ -70,10 +76,12 @@ class SourceGenDslDelegate {
           HeliumInitializer.taskName("generate${name.capitalize()}", specification, config),
           SourceCodeGenerators.GENERATORS[name].task as Class<? extends BaseHeliumTask>
       )
+      tasksMap.put name, task
       HeliumInitializer.configureHeliumTask(task, specification, delegate.output, classpath, userConfig)
       task.setOptions delegate.genOptions
       config.sourceGen(specification)[name] = task
     }
+    return tasksMap
   }
 
   static final class GeneratorDslDelegate {

--- a/gradle-plugin/src/test/groovy/com/stanfy/helium/gradle/HeliumPluginSourceGenSpec.groovy
+++ b/gradle-plugin/src/test/groovy/com/stanfy/helium/gradle/HeliumPluginSourceGenSpec.groovy
@@ -279,6 +279,9 @@ class HeliumPluginSourceGenSpec extends Specification {
     project.helium.sourceGen('s1').jsonSchema.options != null
     project.helium.sourceGen('Testspec1').jsonSchema instanceof GenerateJsonSchemaTask
     project.helium.sourceGen('Testspec2').jsonSchema instanceof GenerateJsonSchemaTask
+    project.tasks.generateJsonSchema != null
+    project.tasks.generateJsonSchemaTestspec1 != null
+    project.tasks.generateJsonSchemaTestspec2 != null
   }
 
   def "source generation should support json scheme generator"() {
@@ -303,6 +306,29 @@ class HeliumPluginSourceGenSpec extends Specification {
     task != null
     task.output == project.file("../jjj")
     task.options != null
+  }
+
+  def "multiple spec trigger tasks should be created for source gen"() {
+    given:
+    project.helium {
+      File outputDir = project.file("../jjj")
+
+      specification(generateSpec("s2"))
+      sourceGen {
+        retrofit { }
+        entities { }
+      }
+    }
+
+    createTasks()
+
+    expect:
+    project.tasks["generateRetrofitS1"]
+    project.tasks["generateRetrofitS2"]
+    project.tasks["generateRetrofit"]
+    project.tasks["generateEntitiesS1"]
+    project.tasks["generateEntitiesS2"]
+    project.tasks["generateEntities"]
   }
 
 }


### PR DESCRIPTION
If you have multiple specs S1 and S2, it's handy to have one task
```
jsonSchema
```
that depends both on
```
jsonSchemaS1 and jsonSchema2
```