### PR TITLE
Declare Helium variables in JUnit tests

### DIFF
--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/GenerateApiTestsTask.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/GenerateApiTestsTask.groovy
@@ -47,7 +47,7 @@ test {
 
 dependencies {
   testCompile '${HeliumExtension.HELIUM_DEP}:${HeliumExtension.VERSION}'
-  testCompile 'junit:junit:4.11'
+  testCompile 'junit:junit:4.12'
 }
 """
     }

--- a/helium/src/main/groovy/com/stanfy/helium/dsl/ProjectDsl.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/dsl/ProjectDsl.groovy
@@ -158,7 +158,12 @@ class ProjectDsl implements Project {
     if (spec instanceof File) {
       specFile = spec as File
     } else {
-      specFile = new File(spec as String)
+      def path = spec as String
+      if (path.startsWith("file:") || path.startsWith("jar:")) {
+        specFile = new File(new URI(path))
+      } else {
+        specFile = new File(path)
+      }
     }
     includedFiles.add specFile
     ScriptExtender.fromFile(specFile, charset).withVars(variablesBinding).handle(this)

--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/internal/UniqueName.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/internal/UniqueName.groovy
@@ -1,0 +1,17 @@
+package com.stanfy.helium.handler.codegen.internal
+
+import java.security.MessageDigest;
+
+/**
+ * Generates a new unique name based on the specified file.
+ */
+public class UniqueName {
+
+  static String from(final File file) {
+    String path = file.canonicalPath
+    MessageDigest digest = MessageDigest.getInstance("MD5")
+    digest.update(path.getBytes("UTF-8"))
+    return "helium_".concat(new BigInteger(1, digest.digest()).toString(16).padLeft(32, '0'))
+  }
+
+}

--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/tests/ScenarioTestsGenerator.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/tests/ScenarioTestsGenerator.groovy
@@ -5,12 +5,15 @@ import com.stanfy.helium.DefaultType
 import com.stanfy.helium.dsl.ProjectDsl
 import com.stanfy.helium.dsl.scenario.ScenarioDelegate
 import com.stanfy.helium.dsl.scenario.ScenarioInvoker
+import com.stanfy.helium.handler.codegen.internal.UniqueName
 import com.stanfy.helium.model.Project
 import com.stanfy.helium.model.Service
 import com.stanfy.helium.model.tests.Scenario
 import groovy.transform.CompileStatic
 
 import javax.lang.model.element.Modifier
+
+import static com.squareup.javawriter.JavaWriter.stringLiteral
 
 /**
  * Generator for scenario tests.
@@ -55,27 +58,50 @@ public class ScenarioTestsGenerator extends BaseUnitTestsGenerator {
 
   }
 
-  private void copy(final Project project) {
-    // XXX temp solution
-    specFile.withWriter(UTF_8) { Writer out ->
-      DefaultType.values().each { DefaultType type ->
-        out << "type '${type.langName}'\n"
-      }
-
-      if (project instanceof ProjectDsl) {
-        Binding vars = project.variablesBinding
-        vars.variables.each { key, value ->
-          out << "def $key = " << JavaWriter.stringLiteral("$value") << '\n'
+  private static String replaceVarsInSpec(final File file, final Map<File, String> map, final Project project) {
+    def text = file.getText("UTF-8")
+    if (project instanceof ProjectDsl) {
+      if (project.variablesBinding.hasVariable("baseDir")) {
+        GroovyShell shell = new GroovyShell(project.variablesBinding)
+        text = text.replaceAll(/include\s+(["'].+?["'])/) { _, arg ->
+          String path = shell.evaluate(arg as String) as String
+          return "include \"\$baseDir/${map[new File(path)]}\""
         }
       }
+    }
+    return text
+  }
 
-      out << scenariosFile.getText(UTF_8)
+  private void copy(final Project project) {
+    def includeMap = [:]
+    project.includedFiles.each { File includedSpec ->
+      String name = UniqueName.from(includedSpec)
+      includeMap[includedSpec] = name
+    }
+    includeMap.each { key, value ->
+      File file = key as File
+      String name = value as String
+      new File(getResourcesPackageDir(), name).withWriter(UTF_8) { Writer out ->
+        out << "// $file.absolutePath\n\n"
+        out << replaceVarsInSpec(file, includeMap, project)
+      }
+    }
+    specFile.withWriter(UTF_8) { Writer out ->
+      DefaultType.values().each { DefaultType type ->
+        try {
+          project.types.byName(type.langName)
+          out << "type '${type.langName}'\n"
+        } catch (IllegalArgumentException ignored) {
+          // no such type
+        }
+      }
+      out << replaceVarsInSpec(scenariosFile, includeMap, project)
     }
   }
 
   @Override
-  protected void startTest(final JavaWriter writer, final Service service) throws IOException {
-    super.startTest(writer, service)
+  protected void startTest(final JavaWriter writer, final Service service, final Project project) throws IOException {
+    super.startTest(writer, service, project)
     writer.emitField(Service.name, "service")
     writer.emitField(ScenarioDelegate.canonicalName, "proxy", EnumSet.of(Modifier.PRIVATE))
 
@@ -87,7 +113,7 @@ public class ScenarioTestsGenerator extends BaseUnitTestsGenerator {
 
     writer.beginMethod(Project.name, "loadDefaultTestSpec", PROTECTED)
     writer.emitStatement("${Project.name} project = super.loadDefaultTestSpec()")
-    writer.emitStatement("this.service = project.serviceByName(%s)", JavaWriter.stringLiteral(service.name))
+    writer.emitStatement("this.service = project.serviceByName(%s)", stringLiteral(service.name))
     writer.emitStatement("return project")
     writer.endMethod()
     writer.emitEmptyLine()
@@ -101,7 +127,7 @@ public class ScenarioTestsGenerator extends BaseUnitTestsGenerator {
     writer.beginMethod("void", scenario.canonicalName, Collections.<Modifier>singleton(Modifier.PUBLIC))
 
     writer.emitStatement("${Scenario.canonicalName} scenario = service.getTestInfo().scenarioByName(%s)",
-        JavaWriter.stringLiteral(scenario.name))
+        stringLiteral(scenario.name))
     writer.emitStatement("${ScenarioInvoker.canonicalName}.invokeScenario(proxy, scenario)")
 
     writer.endMethod()

--- a/helium/src/test/groovy/com/stanfy/helium/dsl/ProjectDslSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/dsl/ProjectDslSpec.groovy
@@ -396,6 +396,20 @@ class ProjectDslSpec extends Specification {
     dsl.includedFiles[-1] == file
   }
 
+  def "can do nested includes"() {
+    given:
+    def file = new File(ProjectDslSpec.class.getResource("/include-nested.spec").toURI())
+    dsl.variablesBinding.setVariable("baseDir", file.parentFile.toURI().toString())
+
+    when:
+    dsl.include file
+
+    then:
+    dsl.notes[-1].value == "I'm included 2"
+    dsl.notes[-2].value == "I'm included"
+    dsl.includedFiles[-2] == file
+  }
+
   def "can user parseString for custom types"() {
     when:
     dsl.type "custom" spec {

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/tests/ScenarioTestsGeneratorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/tests/ScenarioTestsGeneratorSpec.groovy
@@ -12,18 +12,22 @@ class ScenarioTestsGeneratorSpec extends Specification {
 
   ScenarioTestsGenerator generator
 
-  File spec, included, out
+  File spec, out
+
+  File includedSpec
+  String baseDir
 
   def setup() {
     spec = File.createTempFile("hel", "test-spec")
     spec.deleteOnExit()
-    included = new File(spec.parentFile, "included-spec")
-    included.withWriter("UTF-8") { Writer out ->
-      out << "type 'A' message {}"
-    }
+
+    def includedSpecUri = getClass().getResource("/include-nested.spec").toURI()
+    includedSpec = new File(includedSpecUri)
+    baseDir = includedSpec.parentFile.toURI().toString()
+
     spec.withWriter("UTF-8") { Writer out ->
-      out << '''
-        include "${baseDir}/included-spec"
+      out << """
+        include "\${baseDir}/${includedSpec.name}"
         service {
           name "Main"
           tests {
@@ -42,7 +46,7 @@ class ScenarioTestsGeneratorSpec extends Specification {
         service {
           name "Test 3"
         }
-      '''
+      """
     }
     out = File.createTempDir()
     out.deleteOnExit()
@@ -60,7 +64,7 @@ class ScenarioTestsGeneratorSpec extends Specification {
   }
 
   private void run() {
-    new Helium().set("baseDir", spec.parentFile).from(spec).processBy generator
+    new Helium().set("baseDir", baseDir).set("v1", "value").from(spec).processBy generator
   }
 
   def "generates file per service"() {
@@ -107,6 +111,16 @@ class ScenarioTestsGeneratorSpec extends Specification {
     then:
     def e = thrown(IllegalStateException)
     e.message.contains "service name"
+  }
+
+  def "set variables"() {
+    when:
+    run()
+    def text = (findFiles { it.name == 'MainScenariosTest.java' })[0]?.text
+    then:
+    text.contains "void prepareVariables(final Helium helium) {"
+    !text.contains("helium.set(\"baseDir\"")
+    text.contains "helium.set(\"v1\", \"value\");"
   }
 
 }

--- a/helium/src/test/resources/include-nested.spec
+++ b/helium/src/test/resources/include-nested.spec
@@ -1,0 +1,2 @@
+include "$baseDir/included.spec"
+note "I'm included 2"

--- a/samples/multiple-specs/common.api
+++ b/samples/multiple-specs/common.api
@@ -1,3 +1,5 @@
+include "$baseDir/description.api"
+
 def TIMESTAMP_FORMAT = "EEE MMM dd HH:mm:ss Z yyyy"
 
 type "timestamp" spec {

--- a/samples/multiple-specs/description.api
+++ b/samples/multiple-specs/description.api
@@ -1,0 +1,4 @@
+note """
+  This part is included to test issue #73.
+  https://github.com/stanfy/helium/issues/73
+"""


### PR DESCRIPTION
Now we handle all included specs and copy them to test resources.
As a result generated code does not depend on sources.

Closes #73.