### PR TITLE
Observable wrappers

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitGeneratorOptions.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitGeneratorOptions.java
@@ -23,6 +23,7 @@ public class RetrofitGeneratorOptions extends JavaGeneratorOptions {
     options.setPackageName(packageName);
     options.setPrettifyNames(true);
     options.setUseMethodNames(true);
+    options.setUseRxObservables(false);
     return options;
   }
 

--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitGeneratorOptions.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitGeneratorOptions.java
@@ -5,7 +5,7 @@ import com.stanfy.helium.model.ServiceMethod;
 import com.stanfy.helium.utils.Names;
 
 /**
- * Options for Retorfit generator.
+ * Options for Retrofit generator.
  */
 public class RetrofitGeneratorOptions extends JavaGeneratorOptions {
 
@@ -14,6 +14,9 @@ public class RetrofitGeneratorOptions extends JavaGeneratorOptions {
 
   /** Whether to use service method names to generate java method names. */
   private boolean useMethodNames;
+
+  /** Whether to wrap response types in rx.Observable generic. */
+  private boolean useRxObservables;
 
   public static RetrofitGeneratorOptions defaultOptions(final String packageName) {
     RetrofitGeneratorOptions options = new RetrofitGeneratorOptions();
@@ -39,6 +42,14 @@ public class RetrofitGeneratorOptions extends JavaGeneratorOptions {
     this.useMethodNames = useMethodNames;
   }
 
+  public boolean isUseRxObservables() {
+    return useRxObservables;
+  }
+
+  public void setUseRxObservables(final boolean useRxObservables) {
+    this.useRxObservables = useRxObservables;
+  }
+
   String getMethodName(final ServiceMethod method) {
     if (!useMethodNames || method.getName() == null) {
       return getName(method);
@@ -53,5 +64,4 @@ public class RetrofitGeneratorOptions extends JavaGeneratorOptions {
     }
     return name;
   }
-
 }

--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
@@ -137,6 +137,9 @@ public class RetrofitInterfaceGenerator extends BaseJavaGenerator<RetrofitGenera
           }
         }
       }
+      if (options.isUseRxObservables()) {
+        imports.add("rx.Observable");
+      }
 
       writer.emitImports(imports);
       writer.emitImports(RETROFIT_PACKAGE.concat("*"));
@@ -180,6 +183,10 @@ public class RetrofitInterfaceGenerator extends BaseJavaGenerator<RetrofitGenera
         if (m.getResponse() != null) {
           responseType = resolveJavaTypeName(m.getResponse(), writer);
         }
+        if (options.isUseRxObservables()) {
+          responseType = writer.compressType("Observable<" + responseType + ">");
+        }
+
         writer.beginMethod(responseType, options.getMethodName(m), EnumSet.noneOf(Modifier.class),
             resolveParameters(m, writer), Collections.<String>emptyList());
         writer.endMethod();

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
@@ -276,10 +276,6 @@ public interface FormService {
     def text = new File("$output/test/api/ReactiveService.java").text
 
     then:
-    // TODO debug, remove
-    System.err.println "ReactiveService:"
-    System.err.println text
-
     text.contains "rx.Observable"
     text.contains "Observable<SomeResponse>"
     text.contains "Observable<SomeResponse>"

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
@@ -277,8 +277,8 @@ public interface FormService {
 
     then:
     text.contains "rx.Observable"
-    text.contains "Observable<SomeResponse>"
-    text.contains "Observable<SomeResponse>"
+    text.contains "Observable<SomeResponse> postAdd(@Body TheRequest body)"
+    text.contains "Observable<SomeResponse> getList(@Query(\"count\") int count, @Query(\"name\") String name)"
 
   }
 }


### PR DESCRIPTION
Add using rx.Observable wrapping in retrofit interface generation.

This allows to leverage retrofit's built in support of rx.Observables.