### PR TITLE
Fix form imports.

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
@@ -123,18 +123,8 @@ public class RetrofitInterfaceGenerator extends BaseJavaGenerator<RetrofitGenera
         }
 
         if (m.getBody() != null) {
-          addImport(imports, m.getBody(), writer);
-          if (m.getBody() instanceof DataType) {
-            imports.add("retrofit.mime.TypedOutput");
-          } else if (m.getBody() instanceof MultipartType) {
-            if (((MultipartType) m.getBody()).isGeneric()) {
-              imports.add("java.util.Map");
-            } else {
-              for (Type type : ((MultipartType) m.getBody()).getParts().values()) {
-                addImport(imports, type, writer);
-              }
-            }
-          }
+          processImportsForBody(imports, writer, m);
+
         }
       }
       if (options.isUseRxObservables()) {
@@ -197,6 +187,29 @@ public class RetrofitInterfaceGenerator extends BaseJavaGenerator<RetrofitGenera
     } finally {
       IOUtils.closeQuietly(writer);
     }
+  }
+
+  private void processImportsForBody(final Set<String> imports, final JavaWriter writer, final ServiceMethod m) {
+    if (m.getBody() instanceof DataType) {
+      imports.add("retrofit.mime.TypedOutput");
+    }
+
+    if (m.getBody() instanceof MultipartType) {
+      final MultipartType multipartType = (MultipartType) m.getBody();
+      if (multipartType.isGeneric()) {
+        imports.add("java.util.Map");
+      } else {
+        for (Type type : multipartType.getParts().values()) {
+          addImport(imports, type, writer);
+        }
+      }
+    }
+    // Form type is an anonymous wrapper - don't import it.
+    if ((m.getBody() instanceof FormType)) {
+      return;
+    }
+
+    addImport(imports, m.getBody(), writer);
   }
 
   private void writeJavaDoc(final JavaWriter writer, final ServiceMethod m) throws IOException {

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
@@ -156,7 +156,6 @@ class RetrofitInterfaceGeneratorSpec extends Specification {
     text == """
 package test.api;
 
-import FormMessage;
 import retrofit.client.Response;
 import retrofit.http.*;
 
@@ -167,6 +166,33 @@ public interface FormService {
   Response postForm(@Field("count") int count);
 
 }""".trim() + '\n'
+  }
+
+  def "should not import form body wrappers"() {
+    given: "post with form"
+
+    project.type 'string'
+    project.service {
+      name "TheService"
+
+      post "/users" spec {
+        name "register_user"
+        parameters {
+          department 'string'
+        }
+        body form {
+          firstname 'string'
+          lastname 'string'
+        }
+      }
+    }
+
+    when: "dsl is parsed"
+    gen.handle project
+    def text = new File("$output/test/api/TheService.java").text
+
+    then: "result interface should not contain invalid imports"
+    !text.contains("import post_users_body_POST;")
   }
 
   def "should write generic data body"() {


### PR DESCRIPTION
Remove importing form wrapper types for method body in retrofit interface generator.
See issue #103. 

/cc @roman-mazur 