### PR TITLE
Fix extending codegen.

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/ClassAncestors.java
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/codegen/java/ClassAncestors.java
@@ -13,7 +13,7 @@ public class ClassAncestors {
   }
 
   public static ClassAncestors extending(final String name) {
-    return extending(name, (String[]) null);
+    return extending(name, new String[]{});
   }
 
   public static ClassAncestors implementing(final String... interfaces) {

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 import javax.lang.model.element.Modifier
 import static com.stanfy.helium.handler.codegen.java.entity.Writers.*
 import com.stanfy.helium.handler.codegen.java.constants.ConstantNameConverter
+import static com.stanfy.helium.handler.codegen.java.ClassAncestors.*
 
 helium {
   specification file('src/api/twitter.api')
@@ -77,6 +78,10 @@ helium {
             timestamp: "java.util.Date"
         ]
 
+        // Add custom inheritance mapping for generated entities.
+        customParentMapping = [
+          Base: extending("com.stanfy.helium.sample.android.BaseModel")
+        ]
         // Force using Java arrays instead of collections for sequences:
         // currently the only option supported by androidParcelable() feature.
         useArraysForSequences()

--- a/samples/android/src/main/java/com/stanfy/helium/sample/android/BaseModel.java
+++ b/samples/android/src/main/java/com/stanfy/helium/sample/android/BaseModel.java
@@ -1,0 +1,6 @@
+package com.stanfy.helium.sample.android;
+
+// An empty class to see custom inheritance in java codegen.
+public class BaseModel {
+
+}


### PR DESCRIPTION
Fix NPE when chaining AndroidParcelable writer with entity writer and customParentMapping with only parent class and no interfaces.