### PR TITLE
Fix several include issues

### DIFF
--- a/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/BaseHeliumTask.groovy
+++ b/gradle-plugin/src/main/groovy/com/stanfy/helium/gradle/tasks/BaseHeliumTask.groovy
@@ -41,8 +41,7 @@ abstract class BaseHeliumTask<T> extends DefaultTask {
         }
       }
       if (input) {
-        File baseDir = input.parentFile
-        heliumInstance.set "baseDir", baseDir from input
+        heliumInstance.from input
       }
     }
     return heliumInstance

--- a/helium/src/main/groovy/com/stanfy/helium/Helium.java
+++ b/helium/src/main/groovy/com/stanfy/helium/Helium.java
@@ -1,9 +1,9 @@
 package com.stanfy.helium;
 
-import com.stanfy.helium.internal.dsl.ProjectDsl;
 import com.stanfy.helium.handler.ClosureExtender;
 import com.stanfy.helium.handler.Handler;
 import com.stanfy.helium.handler.ScriptExtender;
+import com.stanfy.helium.internal.dsl.ProjectDsl;
 import com.stanfy.helium.model.Project;
 import groovy.lang.Closure;
 

--- a/helium/src/main/groovy/com/stanfy/helium/handler/ScriptExtender.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/handler/ScriptExtender.groovy
@@ -21,6 +21,8 @@ class ScriptExtender implements Handler {
   private final HeliumScript initScript
   /** Source. */
   private final GroovyCodeSource initSource
+  /** Base directory for the script. */
+  private final File baseDir
 
   /** Defined variables. */
   private Binding vars
@@ -28,6 +30,7 @@ class ScriptExtender implements Handler {
   public ScriptExtender(final HeliumScript script) {
     this.initScript = script
     this.initSource = null
+    this.baseDir = null;
   }
 
   public ScriptExtender(final Reader scriptReader) {
@@ -37,17 +40,22 @@ class ScriptExtender implements Handler {
   public ScriptExtender(final Reader scriptReader, final String name, final String path) {
     this.initSource = new GroovyCodeSource(scriptReader, name, path)
     this.initScript = null
+    this.baseDir = new File(path)
   }
 
   public static ScriptExtender fromFile(final File scriptFile, final Charset encoding) throws IOException {
     return new ScriptExtender(
         new InputStreamReader(new FileInputStream(scriptFile), encoding),
-        scriptFile.getName().replaceAll(/\W+/, "_"), DEFAULT_USER_PATH
+        scriptFile.getName().replaceAll(/\W+/, "_"),
+        scriptFile.parentFile.absolutePath
     )
   }
 
   ScriptExtender withVars(final Binding vars) {
-    this.vars = vars
+    this.vars = new Binding(new HashMap(vars.getVariables()))
+    if (baseDir && !this.vars.hasVariable("baseDir")) {
+      this.vars.setVariable("baseDir", baseDir)
+    }
     return this
   }
 

--- a/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
@@ -200,8 +200,10 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
         specFile = new File(path)
       }
     }
-    includedFiles.add specFile
-    ScriptExtender.fromFile(specFile, charset).withVars(variablesBinding).handle(this)
+    if (!includedFiles.contains(specFile)) {
+      includedFiles.add specFile
+      ScriptExtender.fromFile(specFile, charset).withVars(variablesBinding).handle(this)
+    }
   }
 
   BehaviourDescriptionBuilder describe(final String name) {

--- a/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
@@ -445,21 +445,33 @@ class ProjectDslSpec extends Specification {
     dsl.include file
 
     then:
-    dsl.notes[-1].value == "I'm included"
+    dsl.notes[-2].value == "I'm included"
+    !dsl.notes[-1].value.empty
     dsl.includedFiles[-1] == file
+  }
+
+  def "ignores already included files"() {
+    given:
+    def file = new File(ProjectDslSpec.class.getResource("/included.spec").toURI())
+
+    when:
+    dsl.include file
+    dsl.include file
+
+    then:
+    dsl.includedFiles.size() == 1
   }
 
   def "can do nested includes"() {
     given:
     def file = new File(ProjectDslSpec.class.getResource("/include-nested.spec").toURI())
-    dsl.variablesBinding.setVariable("baseDir", file.parentFile.toURI().toString())
 
     when:
     dsl.include file
 
     then:
     dsl.notes[-1].value == "I'm included 2"
-    dsl.notes[-2].value == "I'm included"
+    dsl.notes[-3].value == "I'm included"
     dsl.includedFiles[-2] == file
   }
 

--- a/helium/src/test/resources/included.spec
+++ b/helium/src/test/resources/included.spec
@@ -1,1 +1,2 @@
 note "I'm included"
+note "${baseDir}"

--- a/samples/multi-imports/a.api
+++ b/samples/multi-imports/a.api
@@ -1,0 +1,3 @@
+note "a"
+include "$baseDir/c.api"
+type 'A' message { }

--- a/samples/multi-imports/build.gradle
+++ b/samples/multi-imports/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+  repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+  }
+  dependencies {
+    classpath 'com.stanfy.helium:gradle-plugin:0.6.1-SNAPSHOT'
+  }
+}
+
+apply plugin: 'helium'
+
+helium {
+  specification file('include/b.api')
+}
+
+task check(dependsOn: 'checkApiBehaviour')
+task clean(type: Delete) {
+  delete buildDir
+}

--- a/samples/multi-imports/c.api
+++ b/samples/multi-imports/c.api
@@ -1,0 +1,2 @@
+note "c"
+type 'C' message { }

--- a/samples/multi-imports/include/b.api
+++ b/samples/multi-imports/include/b.api
@@ -1,0 +1,5 @@
+type 'B' message { }
+note "b"
+include "$baseDir/../a.api"
+// This should be ignored.
+include "$baseDir/../c.api"

--- a/samples/multiple-specs/build.gradle
+++ b/samples/multiple-specs/build.gradle
@@ -28,6 +28,7 @@ helium {
 
   variables {
     host 'api.twitter.com'
+    baseDir projectDir
   }
 }
 


### PR DESCRIPTION
baseDir variable is now implicitly set to the spec directory.
This helps a lot with including specs from different folders.
Gradle task does not set baseDir variable any more.
But you can do it explicitly in your build.gradle.

Also now we ignore duplicated includes: we do not include an already included spec.