### PR TITLE
Fix multipart/form-data issue

### DIFF
--- a/helium/src/main/groovy/com/stanfy/helium/model/MultipartType.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/model/MultipartType.groovy
@@ -21,7 +21,7 @@ class MultipartType extends Type {
     if (!isSubtypeAllowed(subtype)) {
       throw new IllegalArgumentException("Bad content type of multipart body: $subtype")
     }
-    this.@subtype = Subtype.valueOf(subtype.toUpperCase(Locale.US))
+    this.@subtype = Subtype.from(subtype)
   }
 
   MultipartType() {
@@ -49,7 +49,19 @@ class MultipartType extends Type {
     ALTERNATIVE,
     DIGEST,
     PARALLEL,
-    FORM
+    FORM_DATA{
+      @Override
+      String representation() {
+        return 'form-data'
+      }
+    }
+
+    public static Subtype from(final String str) {
+      if ('form-data'.equalsIgnoreCase(str)) {
+        return FORM_DATA
+      }
+      return valueOf(str.toUpperCase(Locale.US))
+    }
 
     public String representation() {
       this.name().toLowerCase()

--- a/helium/src/test/groovy/com/stanfy/helium/handler/codegen/tests/HttpExecutorSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/handler/codegen/tests/HttpExecutorSpec.groovy
@@ -48,7 +48,7 @@ class HttpExecutorSpec extends Specification {
       }
 
       post '/upload_multipart' spec {
-        body multipart('form') {
+        body multipart('form-data') {
           name 'string'
           dragon_bytes data()
         }
@@ -124,7 +124,7 @@ class HttpExecutorSpec extends Specification {
 
     then:
     println("Recieved headers: " + sent.headers)
-    sent.getHeader("Content-Type").contains "multipart/form"
+    sent.getHeader("Content-Type").startsWith "multipart/form-data"
     receivedBody != null
     receivedBody.contains "Dragon!!!"
     receivedBody.contains "1234567890"

--- a/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
@@ -943,7 +943,7 @@ class ProjectDslSpec extends Specification {
         name 'Upload parts'
 
         post '/upload' spec {
-          body multipart("${type.name().toLowerCase()}")
+          body multipart("${type.representation()}")
         }
       }
       Type body = dsl.serviceByName("Upload parts").methods.first().body
@@ -982,7 +982,7 @@ class ProjectDslSpec extends Specification {
 
       post '/upload' spec {
         response 'int32'
-        body multipart("form") {
+        body multipart("form-data") {
           title  'string'
           number 'int32'
           person 'Person'
@@ -995,7 +995,7 @@ class ProjectDslSpec extends Specification {
 
     then:
     body instanceof MultipartType
-    (body as MultipartType).subtype == MultipartType.Subtype.FORM
+    (body as MultipartType).subtype == MultipartType.Subtype.FORM_DATA
     (body as MultipartType).parts["title"].name == 'string'
     (body as MultipartType).parts["number"].name == 'int32'
     (body as MultipartType).parts["person"] instanceof Message

--- a/samples/httpbin/build.gradle
+++ b/samples/httpbin/build.gradle
@@ -24,8 +24,8 @@ task prepare(type: Copy) {
   into 'build/generated/source/helium/api-tests/httpbin/'
 }
 
-task check()
+task check(dependsOn: prepare)
 afterEvaluate {
-  check.dependsOn 'genApiTests'
+  check.dependsOn 'runApiTests', 'checkApiBehaviour'
   prepare.dependsOn 'genApiTests'
 }

--- a/samples/httpbin/httpbin.api
+++ b/samples/httpbin/httpbin.api
@@ -96,33 +96,28 @@ service {
 
   post "/post" spec {
     response "UploadTextAndFileResponse"
-    body multipart {
+    body multipart('form-data') {
       text 'string'
       file file()
     }
   }
 
-  tests {
-    scenario "upload a pig" spec {
-      File f = new File("pig.png")
-      System.err.println f.getAbsolutePath()
+  describe "upload pig" spec {
+    File f = new File("$baseDir/pig.png")
+    System.err.println f.getAbsolutePath()
 
-      String pigName = 'This is a pig.'
+    String pigName = 'This is a pig.'
 
-      def res = post "/post" with {
-        body multipart {
-          file f
-          text pigName
-        }
+    def res = service.post "/post" with {
+      body multipart {
+        file f
+        text pigName
       }
-
-      res.mustSucceed()
-
-      assert res.body?.form?.text.contains("This is a pig.")
-      // httpbin returns base64 encoded data
-      assert res.body?.files?.file?.contains(f.bytes.encodeBase64().toString())
     }
 
+    it("must succeed") { res.mustSucceed() }
+    it("submits text") { res.body?.form?.text.contains("This is a pig.") }
+    it("submits file") { res.body?.files?.file?.contains(f.bytes.encodeBase64().toString()) }
   }
 
 }


### PR DESCRIPTION
In tests we were supplying multipart/form instead of multipart/form-data.
httbin tests were broken because of this. Their execution now added to integration tests.

/cc @nolia 