### PR TITLE
Add DSL support for dictionaries

### DIFF
--- a/codegen/java/retrofit/src/main/java/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
+++ b/codegen/java/retrofit/src/main/java/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGenerator.java
@@ -4,6 +4,7 @@ import com.squareup.javawriter.JavaWriter;
 import com.stanfy.helium.handler.Handler;
 import com.stanfy.helium.handler.codegen.java.BaseJavaGenerator;
 import com.stanfy.helium.model.DataType;
+import com.stanfy.helium.model.Dictionary;
 import com.stanfy.helium.model.Field;
 import com.stanfy.helium.model.FileType;
 import com.stanfy.helium.model.FormType;
@@ -101,9 +102,15 @@ public class RetrofitInterfaceGenerator extends BaseJavaGenerator<RetrofitGenera
       }
       importedType = ((Sequence) importedType).getItemsType();
     }
-    String name = resolveJavaTypeName(importedType, writer, false);
-    if (name.contains(".")) {
-      imports.add(name);
+    if (importedType instanceof Dictionary) {
+      imports.add("java.util.Map");
+      addImport(imports, ((Dictionary) importedType).getKey(), writer);
+      addImport(imports, ((Dictionary) importedType).getValue(), writer);
+    } else {
+      String name = resolveJavaTypeName(importedType, writer, false);
+      if (name.contains(".")) {
+        imports.add(name);
+      }
     }
   }
 

--- a/codegen/java/retrofit/src/test/java/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
+++ b/codegen/java/retrofit/src/test/java/com/stanfy/helium/handler/codegen/java/retrofit/RetrofitInterfaceGeneratorSpec.groovy
@@ -23,6 +23,7 @@ class RetrofitInterfaceGeneratorSpec extends Specification {
     project.type 'AMessage' message { }
     project.type 'BMessage' message { }
     project.type 'BList' sequence 'BMessage'
+    project.type 'Map' dictionary('int32', 'AMessage')
     project.service {
       name "A"
       location "http://www.stanfy.com"
@@ -55,6 +56,12 @@ class RetrofitInterfaceGeneratorSpec extends Specification {
         parameters {
           state 'int32' sequence
         }
+      }
+
+      post '/map' spec {
+        name 'Check map type'
+        body 'Map'
+        response 'Map'
       }
     }
     project.service {
@@ -163,6 +170,15 @@ class RetrofitInterfaceGeneratorSpec extends Specification {
     text.contains('"HC1: cvalue1",')
     text.contains('"HC2: cvalue2"')
     text.contains('BMessage getHeaders(@Header("H1") String headerH1, @Header("H2") String headerH2)')
+  }
+
+  def "dictionaries in body"() {
+    when:
+    gen.handle(project)
+    def text = new File("$output/test/api/A.java").text
+
+    then:
+    text.contains('Map<Integer, AMessage> checkMapType(@Body Map<Integer, AMessage> body)')
   }
 
   def "good message for missing service name"() {

--- a/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/internal/dsl/ProjectDsl.groovy
@@ -26,6 +26,8 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
   private final List<Message> messages = new ArrayList<>()
   /** Sequences list. */
   private final List<Sequence> sequences = new ArrayList<>()
+  /** Dictionaries list. */
+  private final List<Dictionary> dictionaries = new ArrayList<>()
   /** Notes list. */
   private final List<Note> notes = new ArrayList<>()
   /** Included files list. */
@@ -93,6 +95,12 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
     return Collections.unmodifiableList(sequences)
   }
 
+  @Override
+  List<Dictionary> getDictionaries() {
+    applyPendingTypes()
+    return Collections.unmodifiableList(dictionaries)
+  }
+
   @PackageScope
   TypeResolver getTypeResolver() { return typeResolver }
 
@@ -120,6 +128,23 @@ class ProjectDsl implements Project, BehaviorDescriptionContainer {
     sequences.add seq
     updatePendingTypes(name, seq, true)
     return seq
+  }
+
+  public Dictionary createAndAddDictionary(final String name, final String keyType, final String valueType) {
+    if (!keyType) {
+      throw new IllegalArgumentException("Key type is not defined for dictionary $name")
+    }
+    if (!valueType) {
+      throw new IllegalArgumentException("Value type is not defined for dictionary $name")
+    }
+    Dictionary dict = new Dictionary(
+        name : name,
+        key: typeResolver.byName(keyType),
+        value: typeResolver.byName(valueType)
+    )
+    dictionaries.add dict
+    updatePendingTypes(name, dict, true)
+    return dict
   }
 
   public void updatePrimitiveType(final Type type) {

--- a/helium/src/main/groovy/com/stanfy/helium/internal/dsl/TypeDsl.groovy
+++ b/helium/src/main/groovy/com/stanfy/helium/internal/dsl/TypeDsl.groovy
@@ -2,6 +2,7 @@ package com.stanfy.helium.internal.dsl
 
 import com.squareup.okhttp.MediaType
 import com.stanfy.helium.internal.entities.json.ClosureJsonConverter
+import com.stanfy.helium.model.Dictionary
 import com.stanfy.helium.model.Message
 import com.stanfy.helium.model.Sequence
 import com.stanfy.helium.model.Type
@@ -54,6 +55,14 @@ class TypeDsl {
 
   Sequence sequence(final String item) {
     return dsl.createAndAddSequence(type.name, item)
+  }
+
+  Dictionary dictionary(final Map<String, String> args) {
+    return dsl.createAndAddDictionary(type.name, args.key, args.value)
+  }
+
+  Dictionary dictionary(final String key, final String value) {
+    return dsl.createAndAddDictionary(type.name, key, value)
   }
 
   void spec(final Closure<?> spec) {

--- a/helium/src/main/groovy/com/stanfy/helium/model/Project.java
+++ b/helium/src/main/groovy/com/stanfy/helium/model/Project.java
@@ -37,6 +37,11 @@ public interface Project extends Checkable {
    */
   List<Sequence> getSequences();
 
+  /**
+   * @return dictionaries described in this project
+   */
+  List<Dictionary> getDictionaries();
+
   Service serviceByName(final String name);
 
   /**

--- a/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
+++ b/helium/src/test/groovy/com/stanfy/helium/internal/dsl/ProjectDslSpec.groovy
@@ -5,6 +5,7 @@ import com.stanfy.helium.DefaultTypesLoader
 import com.stanfy.helium.internal.entities.json.ClosureJsonConverter
 import com.stanfy.helium.internal.model.tests.CheckableService
 import com.stanfy.helium.model.DataType
+import com.stanfy.helium.model.Dictionary
 import com.stanfy.helium.model.FileType
 import com.stanfy.helium.model.FormType
 import com.stanfy.helium.model.Message
@@ -157,6 +158,23 @@ class ProjectDslSpec extends Specification {
 
     then:
     dsl.sequences[0].name == 'A'
+  }
+
+  def "can describe dictionaries"() {
+    when:
+    dsl.type 'string'
+    dsl.type 'int32'
+    dsl.type 'A' dictionary(key: 'string', value: 'int32')
+    dsl.type 'B' dictionary('string', 'int32')
+
+    then:
+    dsl.dictionaries[0].name == 'A'
+    dsl.dictionaries[1].name == 'B'
+    dsl.types.byName('A') instanceof Dictionary
+    dsl.types.byName('A').key.name == 'string'
+    dsl.types.byName('A').value.name == 'int32'
+    dsl.types.byName('B').key.name == 'string'
+    dsl.types.byName('B').value.name == 'int32'
   }
 
   def "can describe service methods"() {

--- a/samples/java-retrofit/src/api/my-backend.api
+++ b/samples/java-retrofit/src/api/my-backend.api
@@ -23,6 +23,9 @@ type "UserMessage" message(parent: "BaseResponse") {
   data 'string'
 }
 
+type "PostSequence" sequence "Post"
+type "TaggedPosts" dictionary('string', 'PostSequence')
+
 service {
 
   name "My Backend"
@@ -38,6 +41,12 @@ service {
       options 'int32' sequence
     }
     response 'SearchResponse'
+  }
+
+  post 'posts/tagged' spec {
+    name 'Update tagged posts'
+    body 'TaggedPosts'
+    response 'TaggedPosts'
   }
 
 }

--- a/samples/java-retrofit/src/test/java/com/stanfy/helium/sample/retrofit/SampleTest.java
+++ b/samples/java-retrofit/src/test/java/com/stanfy/helium/sample/retrofit/SampleTest.java
@@ -8,6 +8,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -30,6 +33,8 @@ public class SampleTest {
     Post post = new Post();
     post.user = new User();
     resp.statuses.add(post);
+    Map<String, List<Post>> resp2 = api.updateTaggedPosts(Collections.<String, List<Post>>emptyMap());
+    resp2.get("key");
   }
 
 }


### PR DESCRIPTION
This is the last PR for basic maps support in helium.
Dictionaries are now supported in DSL. behaviour checks and few Java source code generators.
Closes #33.