### PR TITLE
Add Jackson annotations writer

### DIFF
--- a/codegen/java/java-entities/build.gradle
+++ b/codegen/java/java-entities/build.gradle
@@ -9,6 +9,7 @@ apply from: file("$rootDir/gradle/common.gradle")
 evaluationDependsOn(':codegen')
 
 dependencies {
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.3'
   compile project(':codegen:java:java-handler')
   testCompile project(path: ':codegen:java:java-handler', configuration: 'tests')
 }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriter.java
@@ -1,0 +1,34 @@
+package com.stanfy.helium.handler.codegen.java.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.stanfy.helium.model.Field;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Adds {@code JsonProperty} annotations.
+ */
+class JacksonPojoWriter extends DelegateJavaClassWriter {
+
+  public JacksonPojoWriter(final JavaClassWriter core) {
+    super(core);
+  }
+
+  @Override
+  public void writeImports(final Set<String> imports) throws IOException {
+    HashSet<String> newImports = new HashSet<String>(imports.size() + 1);
+    newImports.addAll(imports);
+    newImports.add(JsonProperty.class.getCanonicalName());
+    super.writeImports(newImports);
+  }
+
+  @Override
+  public void writeField(final Field field, final String fieldTypeName, final String fieldName, final Set<Modifier> modifiers) throws IOException {
+    getOutput().emitAnnotation(JsonProperty.class, "\"" + field.getName() + "\"");
+    super.writeField(field, fieldTypeName, fieldName, modifiers);
+  }
+
+}

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/Writers.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/Writers.java
@@ -50,6 +50,18 @@ public final class Writers {
   }
 
   /**
+   * @return writer for object with Jackson {@code JsonProperty} annotations.
+   */
+  public static WriterWrapper jackson() {
+    return new WriterWrapper() {
+      @Override
+      public JavaClassWriter wrapWriter(final JavaClassWriter output, final EntitiesGeneratorOptions options) {
+        return new JacksonPojoWriter(output);
+      }
+    };
+  }
+
+  /**
    * @param wrappers wrappers sequence
    * @return chained wrapper
    */

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/EntitiesGeneratorSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/EntitiesGeneratorSpec.groovy
@@ -52,7 +52,7 @@ public enum Day {
 
   def "should be able to chain writers"() {
     given:
-    options.writerWrapper = Writers.chain(Writers.gson(), Writers.androidParcelable())
+    options.writerWrapper = Writers.chain(Writers.gson(), Writers.androidParcelable(), Writers.jackson())
 
     when:
     generator.handle(project)
@@ -64,6 +64,7 @@ package com.stanfy.helium;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 public class A

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriterSpec.groovy
@@ -1,0 +1,57 @@
+package com.stanfy.helium.handler.codegen.java.entity
+
+import com.stanfy.helium.model.Field
+import com.stanfy.helium.model.Message
+import com.stanfy.helium.model.Type
+import spock.lang.Specification
+/**
+ * Tests for JacksonPojoWriter.
+ */
+class JacksonPojoWriterSpec extends Specification {
+
+  /** Instance under tests. */
+  JacksonPojoWriter writer
+  /** Output. */
+  StringWriter output
+
+  def setup() {
+    output = new StringWriter()
+    writer = new JacksonPojoWriter(new PojoWriter(output))
+  }
+
+  def "should write class file"() {
+    given:
+    Message msg = new Message(name: "MyMsg")
+    msg.addField(new Field(name: "device_id", type: new Type(name: "string")))
+    msg.addField(new Field(name: "another_id", type: new Type(name: "int32")))
+
+    when:
+    new MessageToJavaClass(writer, EntitiesGeneratorOptions.defaultOptions("test")).write(msg)
+
+    then:
+    output.toString() == """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MyMsg {
+
+  @JsonProperty("device_id")
+  public String device_id;
+
+  @JsonProperty("another_id")
+  public int another_id;
+
+
+  @Override
+  public String toString() {
+    return "MyMsg: {\\n"
+         + "  device_id=\\"" + device_id + "\\",\\n"
+         + "  another_id=\\"" + another_id + "\\"\\n"
+         + "}";
+  }
+}
+""".trim() + '\n'
+  }
+
+}


### PR DESCRIPTION
I believe it's possible to hack Jackson ObjectMapper to use SerializedName annotation, but... it's better to rely on native Jackson annotations