### PR TITLE
Add jackson & gson value annotations over enums

### DIFF
--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/DelegateJavaClassWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/DelegateJavaClassWriter.java
@@ -61,4 +61,9 @@ class DelegateJavaClassWriter implements JavaClassWriter {
     core.writeConstructors(message);
   }
 
+  @Override
+  public void writeEnumValue(String name, boolean isLast) throws IOException {
+    core.writeEnumValue(name, isLast);
+  }
+
 }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/EntitiesGenerator.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/EntitiesGenerator.java
@@ -73,7 +73,9 @@ public class EntitiesGenerator extends BaseJavaGenerator<EntitiesGeneratorOption
     OutputStreamWriter output = null;
     try {
       output = new OutputStreamWriter(new FileOutputStream(classFile), "UTF-8");
-      new ConstraintsToEnum(getOptions()).write(type, enumConst, output);
+      JavaClassWriter coreWriter = Writers.pojo().create(output);
+      EntitiesGeneratorOptions options = getOptions();
+      new ConstraintsToEnum(options.getWriterWrapper().wrapWriter(coreWriter, options), options).write(type, enumConst);
     } catch (IOException e) {
       throw new RuntimeException(e);
     } finally {

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/GsonPojoWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/GsonPojoWriter.java
@@ -31,4 +31,9 @@ class GsonPojoWriter extends DelegateJavaClassWriter {
     super.writeField(field, fieldTypeName, fieldName, modifiers);
   }
 
+  @Override
+  public void writeEnumValue(String name, boolean isLast) throws IOException {
+    getOutput().emitAnnotation(SerializedName.class, "\"" + name + "\"");
+    super.writeEnumValue(name, isLast);
+  }
 }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriter.java
@@ -31,4 +31,9 @@ class JacksonPojoWriter extends DelegateJavaClassWriter {
     super.writeField(field, fieldTypeName, fieldName, modifiers);
   }
 
+  @Override
+  public void writeEnumValue(String name, boolean isLast) throws IOException {
+    getOutput().emitAnnotation(JsonProperty.class, "\"" + name + "\"");
+    super.writeEnumValue(name, isLast);
+  }
 }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JavaClassWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/JavaClassWriter.java
@@ -29,4 +29,6 @@ public interface JavaClassWriter {
 
   void writeConstructors(final Message message) throws IOException;
 
+  void writeEnumValue(final String name, final boolean isLast) throws IOException;
+
 }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/PojoWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/PojoWriter.java
@@ -1,6 +1,7 @@
 package com.stanfy.helium.handler.codegen.java.entity;
 
 import com.squareup.javawriter.JavaWriter;
+import com.stanfy.helium.internal.utils.Names;
 import com.stanfy.helium.model.Field;
 import com.stanfy.helium.model.Message;
 
@@ -8,6 +9,7 @@ import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -67,6 +69,11 @@ class PojoWriter implements JavaClassWriter {
   @Override
   public void writeConstructors(final Message message) {
     // nothing
+  }
+
+  @Override
+  public void writeEnumValue(String name, boolean isLast) throws IOException {
+    getOutput().emitEnumValue(Names.canonicalName(name).toUpperCase(Locale.US), isLast);
   }
 
 }

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/GsonPojoWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/GsonPojoWriterSpec.groovy
@@ -3,6 +3,7 @@ package com.stanfy.helium.handler.codegen.java.entity
 import com.stanfy.helium.model.Field
 import com.stanfy.helium.model.Message
 import com.stanfy.helium.model.Type
+import com.stanfy.helium.model.constraints.EnumConstraint
 import spock.lang.Specification
 /**
  * Tests for GsonPojoWriter.
@@ -50,6 +51,29 @@ public class MyMsg {
          + "  another_id=\\"" + another_id + "\\"\\n"
          + "}";
   }
+}
+""".trim() + '\n'
+  }
+
+  def "enumeration annotations written"() {
+    given:
+    EnumConstraint<String> enumConstraint = new EnumConstraint<>(["value1", "value2"])
+    Type enumType = new Type(name: "MyEnum")
+
+    when:
+    new ConstraintsToEnum(writer, EntitiesGeneratorOptions.defaultOptions("test")).write(enumType, enumConstraint)
+
+    then:
+    output.toString() == """
+package test;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum MyEnum {
+  @SerializedName("value1")
+  VALUE1,
+  @SerializedName("value2")
+  VALUE2;
 }
 """.trim() + '\n'
   }

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/JacksonPojoWriterSpec.groovy
@@ -3,6 +3,7 @@ package com.stanfy.helium.handler.codegen.java.entity
 import com.stanfy.helium.model.Field
 import com.stanfy.helium.model.Message
 import com.stanfy.helium.model.Type
+import com.stanfy.helium.model.constraints.EnumConstraint
 import spock.lang.Specification
 /**
  * Tests for JacksonPojoWriter.
@@ -50,6 +51,29 @@ public class MyMsg {
          + "  another_id=\\"" + another_id + "\\"\\n"
          + "}";
   }
+}
+""".trim() + '\n'
+  }
+
+  def "enumeration annotations written"() {
+    given:
+    EnumConstraint<String> enumConstraint = new EnumConstraint<>(["value1", "value2"])
+    Type enumType = new Type(name: "MyEnum")
+
+    when:
+    new ConstraintsToEnum(writer, EntitiesGeneratorOptions.defaultOptions("test")).write(enumType, enumConstraint)
+
+    then:
+    output.toString() == """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MyEnum {
+  @JsonProperty("value1")
+  VALUE1,
+  @JsonProperty("value2")
+  VALUE2;
 }
 """.trim() + '\n'
   }


### PR DESCRIPTION
This brings an important feature to helium: add json-library-specific annotations on enums, in order to keep original constraint value together with valid java code-style upper-case enums. Also, this adds support for the feature for `gson` and `jackson` json libraries. 

/cc @roman-mazur @Vandalko 