### PR TITLE
Fix parcelable generation of boxed types

### DIFF
--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriter.java
@@ -330,19 +330,17 @@ class AndroidParcelableWriter extends DelegateJavaClassWriter {
   }
 
   private Class<?> getJavaClass(final Field field) {
-    return field.getType().isPrimitive() && !(field.getType() instanceof ConstrainedType)
+    Class<?> clazz = field.getType().isPrimitive() && !(field.getType() instanceof ConstrainedType)
         ? options.getPrimitiveJavaClass(field.getType())
         : null;
+    if (!field.isRequired() && options.isBoxPrimitiveOptionals()) {
+      clazz = JavaPrimitiveTypes.box(clazz);
+    }
+    return clazz;
   }
 
   private String getSupportedMethod(final String prefix, final Field field) {
-    if (!field.getType().isPrimitive()) {
-      return null;
-    }
-    Class<?> clazz = JavaPrimitiveTypes.javaClass(field.getType());
-    if (clazz == null) {
-      return null;
-    }
+    Class<?> clazz = getJavaClass(field);
     String namePart = SUPPORTED_TYPES_BY_ANDROID.get(clazz);
     return namePart != null ? prefix.concat(namePart) : null;
   }

--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriter.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriter.java
@@ -333,7 +333,7 @@ class AndroidParcelableWriter extends DelegateJavaClassWriter {
     Class<?> clazz = field.getType().isPrimitive() && !(field.getType() instanceof ConstrainedType)
         ? options.getPrimitiveJavaClass(field.getType())
         : null;
-    if (!field.isRequired() && options.isBoxPrimitiveOptionals()) {
+    if (clazz != null && !field.isRequired() && options.isBoxPrimitiveOptionals()) {
       clazz = JavaPrimitiveTypes.box(clazz);
     }
     return clazz;

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
@@ -625,4 +625,64 @@ public class Message extends Base
     )
   }
 
+  def "should handle primitive types boxing"() {
+    given:
+    Message msg = new Message(name: "MyMsg")
+    msg.addField(new Field(name: "another_id", type: new Type(name: "int32"), required: false))
+
+    options.boxPrimitiveOptionals = true
+
+    when:
+    new MessageToJavaClass(writer, options).write(msg)
+
+    then:
+    output.toString() == """
+package test;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class MyMsg
+    implements Parcelable {
+
+  public static final Creator<MyMsg> CREATOR = new Creator<MyMsg>() {
+        public MyMsg createFromParcel(Parcel source) {
+          return new MyMsg(source);
+        }
+        public MyMsg[] newArray(int size) {
+          return new MyMsg[size];
+        }
+      };
+
+  public Integer another_id;
+
+
+  public MyMsg() {
+  }
+
+  MyMsg(Parcel source) {
+    this.another_id = (Integer) source.readValue(getClass().getClassLoader());
+  }
+
+  @Override
+  public String toString() {
+    return "MyMsg: {\\n"
+         + "  another_id=\\"" + another_id + "\\"\\n"
+         + "}";
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int options) {
+    dest.writeValue(this.another_id);
+  }
+
+}
+""".trim() + '\n'
+  }
+
 }


### PR DESCRIPTION
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'double java.lang.Double.doubleValue()' on a null object reference
       at com.keypr.api.v1.Affiliate.writeToParcel(Affiliate.java:524)
       at android.os.Parcel.writeParcelable(Parcel.java:1437)
       at com.keypr.api.v1.AffiliateData.writeToParcel(AffiliateData.java:54)
       at android.os.Parcel.writeParcelable(Parcel.java:1437)
       at android.os.Parcel.writeValue(Parcel.java:1343)
       at android.os.Parcel.writeArrayMapInternal(Parcel.java:686)
       at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1330)
       at android.os.Bundle.writeToParcel(Bundle.java:1079)
       at android.os.Parcel.writeBundle(Parcel.java:711)
       at android.support.v4.app.FragmentState.writeToParcel(Fragment.java:137)
       at android.os.Parcel.writeTypedArray(Parcel.java:1254)
       at android.support.v4.app.FragmentManagerState.writeToParcel(FragmentManager.java:385)
       at android.os.Parcel.writeParcelable(Parcel.java:1437)
       at android.os.Parcel.writeValue(Parcel.java:1343)
       at android.os.Parcel.writeArrayMapInternal(Parcel.java:686)
       at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1330)
       at android.os.Bundle.writeToParcel(Bundle.java:1079)
       at android.os.Parcel.writeBundle(Parcel.java:711)
       at android.app.ActivityManagerProxy.activityStopped(ActivityManagerNative.java:3153)
       at android.app.ActivityThread$StopInfo.run(ActivityThread.java:3417)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```