### PR TITLE
Include parent toString representation

### DIFF
--- a/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/MessageToJavaClass.java
+++ b/codegen/java/java-entities/src/main/java/com/stanfy/helium/handler/codegen/java/entity/MessageToJavaClass.java
@@ -198,7 +198,13 @@ final class MessageToJavaClass {
     final Writer str = new Writer();
     List<Field> fieldList = message.getActiveFields();
     if (fieldList.size() == 0) {
-      str.add("return \"%s: has no fields\"", message.getName(), singleLine ? "" : "\n");
+      if (message.hasParent()) {
+        str.add("return \"%s: {%s", message.getName(), singleLine ? "\"\n" : "\\n\"\n");
+        str.add(" + \"  @parent = \" + super.toString()");
+        str.add("\n + \"%s}\"", singleLine ? "" : "\\n");
+      } else {
+        str.add("return \"%s: has no fields\"", message.getName(), singleLine ? "" : "\n");
+      }
     } else {
       str.add("return \"%s: {%s", message.getName(), singleLine ? "\"\n" : "\\n\"\n");
 
@@ -225,7 +231,7 @@ final class MessageToJavaClass {
           value = "(" + fieldName + " != null ? " + toString + " : \"null\")";
         }
 
-        boolean notTheLastOne = i < fieldList.size() - 1;
+        boolean notTheLastOne = i < fieldList.size() - 1 || message.hasParent();
         String ending = String.format(" + \"\\\"%s%s\"",
             notTheLastOne ? separator : "",
             singleLine ? " " : "\\n");
@@ -237,11 +243,11 @@ final class MessageToJavaClass {
             ending);
       }
 
-      str.add(" + \"}\"");
-    }
+      if (message.hasParent()) {
+        str.add(" + \"  @parent = \" + super.toString()%s", singleLine ? "\n" : " + \"\\n\"\n");
+      }
 
-    if (message.hasParent()) {
-      str.add("%s+ \"%sparent = \" + super.toString()", singleLine ? " " : "\n ", singleLine ? "; " : "\\n");
+      str.add(" + \"}\"");
     }
 
     writer.getOutput().emitAnnotation(Override.class)

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
@@ -498,9 +498,9 @@ public class Message extends Base
   @Override
   public String toString() {
     return "Message: {\\n"
-         + "  optional=\\"" + optional + "\\"\\n"
-         + "}"
-         + "\\nparent = " + super.toString();
+         + "  optional=\\"" + optional + "\\",\\n"
+         + "  @parent = " + super.toString() + "\\n"
+         + "}";
   }
 
   @Override

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/AndroidParcelableWriterSpec.groovy
@@ -499,7 +499,8 @@ public class Message extends Base
   public String toString() {
     return "Message: {\\n"
          + "  optional=\\"" + optional + "\\"\\n"
-         + "}";
+         + "}"
+         + "\\nparent = " + super.toString();
   }
 
   @Override

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/PojoWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/PojoWriterSpec.groovy
@@ -319,6 +319,30 @@ public class Test {
     )
   }
 
+  def "toString of empty message with parent"() {
+    given:
+    Message msg = new Message(name: "Test")
+    msg.parent = new Message(name: "AbsTest")
+    msg.parent.addField(new Field(name: "old", type: new Type(name: "string")))
+
+    options.addToString = true
+
+    when:
+    new MessageToJavaClass(writer, options).write(msg)
+
+    then:
+    output.toString().contains(
+        '''
+  @Override
+  public String toString() {
+    return "Test: {\\n"
+         + "  @parent = " + super.toString()
+         + "\\n}";
+  }
+'''
+    )
+  }
+
   def "toString for complex message"() {
     given:
     Message msg = new Message(name: "MyMsg")
@@ -444,9 +468,9 @@ public class Test {
   @Override
   public String toString() {
     return "Test: {\\n"
-         + "  newField=\\"" + newField + "\\"\\n"
-         + "}"
-         + "\\nparent = " + super.toString();
+         + "  newField=\\"" + newField + "\\",\\n"
+         + "  @parent = " + super.toString() + "\\n"
+         + "}";
   }
 '''
     )

--- a/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/PojoWriterSpec.groovy
+++ b/codegen/java/java-entities/src/test/groovy/com/stanfy/helium/handler/codegen/java/entity/PojoWriterSpec.groovy
@@ -425,6 +425,33 @@ public class Test {
 ''')
   }
 
+  def "toString message with parent"() {
+    given:
+    Message msg = new Message(name: "Test")
+    msg.addField(new Field(name: "new", type: new Type(name: "string")))
+
+    msg.parent = new Message(name: "AbsTest")
+    msg.parent.addField(new Field(name: "old", type: new Type(name: "string")))
+
+    options.addToString = true
+
+    when:
+    new MessageToJavaClass(writer, options).write(msg)
+
+    then:
+    output.toString().contains(
+        '''
+  @Override
+  public String toString() {
+    return "Test: {\\n"
+         + "  newField=\\"" + newField + "\\"\\n"
+         + "}"
+         + "\\nparent = " + super.toString();
+  }
+'''
+    )
+  }
+
   def "write JavaDoc from Description"() {
     given:
     Message msg = new Message(name: "Test", description: "Some testing class")


### PR DESCRIPTION
My initial idea was to grab parent fields and `toString()` them using getters, but this creates an issue with 3rd-party parent classes which might not have corresponding getters... That's why simply print parent class.